### PR TITLE
fix(ci): Use typing.List for Python 3.8 compatibility

### DIFF
--- a/git_scribe/core/git_utils.py
+++ b/git_scribe/core/git_utils.py
@@ -2,6 +2,7 @@ import git
 import os
 import subprocess
 import tempfile
+from typing import List, Tuple
 
 
 def get_repo() -> git.Repo:
@@ -32,7 +33,7 @@ def get_last_commit_message(repo: git.Repo) -> str:
     return repo.head.commit.message
 
 
-def commit(message: str, commit_args: list[str]):
+def commit(message: str, commit_args: List[str]):
     """Performs the commit, passing through any extra arguments."""
     with tempfile.NamedTemporaryFile(
         mode="w+", delete=False, encoding="utf-8"
@@ -47,7 +48,7 @@ def commit(message: str, commit_args: list[str]):
         os.unlink(tmpfile_path)
 
 
-def get_repo_info(repo: git.Repo) -> tuple[str, str]:
+def get_repo_info(repo: git.Repo) -> Tuple[str, str]:
     """Extracts owner and repo name from the remote URL."""
     try:
         remote_url = repo.remotes.origin.url

--- a/git_scribe/core/github.py
+++ b/git_scribe/core/github.py
@@ -1,9 +1,10 @@
 import requests
+from typing import Optional
 
 
 def get_milestone_id(
     token: str, owner: str, repo_name: str, milestone_name: str
-) -> int | None:
+) -> Optional[int]:
     """Finds the ID of a milestone by its name."""
     api_url = f"https://api.github.com/repos/{owner}/{repo_name}/milestones"
     headers = {
@@ -30,7 +31,7 @@ def create_pull_request(
     reviewers: list,
     assignees: list,
     labels: list,
-    milestone: int | None,
+    milestone: Optional[int],
 ) -> dict:
     """Creates a pull request on GitHub."""
     api_url = f"https://api.github.com/repos/{owner}/{repo_name}/pulls"


### PR DESCRIPTION
This PR fixes a TypeError in the CI pipeline for Python 3.8 by updating the type hints in  to use  instead of the  syntax, which was introduced in Python 3.9.