### PR TITLE
Fix: Update image source and add Zone.Identifier to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 # Swap files
 *.swp
 *.swo
+
+# zone identifier file
+*Zone.Identifier

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # git-scribe
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/popyson1648/git-scribe/main/logo.png" alt="git-scribe logo" height="200"/>
+  <img src="https://raw.githubusercontent.com/popyson1648/git-scribe/main/assets/logo.png" alt="git-scribe logo" height="200"/>
 </p>
 
 <p align="center">

--- a/assets/logo.png:Zone.Identifier
+++ b/assets/logo.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.figma.com/

--- a/assets/rectangle.jpg:Zone.Identifier
+++ b/assets/rectangle.jpg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.figma.com/


### PR DESCRIPTION

### Summary
This PR updates the image source in the README.md file and adds `*Zone.Identifier` to the `.gitignore` file.

### Background
The image source path was incorrect, resulting in a broken image display.  Additionally, Zone.Identifier files were being unnecessarily tracked by git.

### Changes
- Updated the image source in `README.md` to `assets/logo.png`.
- Added `*Zone.Identifier` to `.gitignore` to prevent tracking these files.